### PR TITLE
Update llm_config.yaml to use placeholder API key

### DIFF
--- a/config/run_env_config/llm_config.yaml
+++ b/config/run_env_config/llm_config.yaml
@@ -2,7 +2,7 @@ temperature: 0
 max_tokens: 0
 max_context_window: 200000
 base_url: https://api.moonshot.cn/v1
-api_key: sk-WUytBnyvqpCtEEs12xw9tMiv5KoR32qquFAifcTepx1XP5ww
+api_key: your_api_key_here
 models:
 - openai/kimi-k2-thinking
 figure_models:


### PR DESCRIPTION
Replaced the API key with a placeholder for security.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Security/config update**
> 
> - Redacts the real `api_key` in `config/run_env_config/llm_config.yaml`, replacing it with `your_api_key_here`.
> - No changes to other LLM settings (`temperature`, `models`, `base_url`, etc.).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41812c87d2e5a75be763225a0098d15daa1c9bfe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->